### PR TITLE
Instances for () and Maybe

### DIFF
--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -177,8 +177,8 @@ instance FromHttpApiData L.Text   where parseUrlPiece = Right . L.fromStrict
 instance FromHttpApiData Day      where parseUrlPiece = readEitherUrlPiece
 
 -- |
--- >>> parseUrlPiece "Just 123" :: Either Text Int
--- Just 123
+-- >>> parseUrlPiece "Just 123" :: Either Text (Maybe Int)
+-- Right (Just 123)
 instance FromHttpApiData a => FromHttpApiData (Maybe a) where
   parseUrlPiece "Nothing" = return Nothing
   parseUrlPiece s =

--- a/Web/PathPieces.hs
+++ b/Web/PathPieces.hs
@@ -32,6 +32,7 @@ class PathPiece s where
   default toPathPiece :: ToHttpApiData s => s -> S.Text
   toPathPiece = toUrlPiece
 
+instance PathPiece ()
 instance PathPiece Bool
 instance PathPiece Double
 instance PathPiece Float
@@ -49,10 +50,6 @@ instance PathPiece String
 instance PathPiece S.Text
 instance PathPiece L.Text
 instance PathPiece Day
-
-instance PathPiece () where
-    fromPathPiece t = if t == "_" then Just () else Nothing
-    toPathPiece () = "_"
 
 instance (PathPiece a) => PathPiece (Maybe a) where
     fromPathPiece s = case S.stripPrefix "Just " s of

--- a/Web/PathPieces.hs
+++ b/Web/PathPieces.hs
@@ -9,6 +9,7 @@ module Web.PathPieces (
   PathMultiPiece (..),
   readFromPathPiece,
   showToPathPiece,
+  WrappedPathPiece(..),
 ) where
 
 import Data.Int
@@ -51,15 +52,18 @@ instance PathPiece S.Text
 instance PathPiece L.Text
 instance PathPiece Day
 
-instance (PathPiece a) => PathPiece (Maybe a) where
-    fromPathPiece s = case S.stripPrefix "Just " s of
-        Just r -> Just `fmap` fromPathPiece r
-        _ -> case s of
-            "Nothing" -> Just Nothing
-            _ -> Nothing
-    toPathPiece m = case m of
-        Just s -> "Just " `S.append` toPathPiece s
-        _ -> "Nothing"
+-- | Wrapped @'PathPiece'@ value.
+newtype WrappedPathPiece a = WrappedPathPiece { unwrapPathPiece :: a }
+
+instance PathPiece a => ToHttpApiData (WrappedPathPiece a) where
+  toUrlPiece = toPathPiece . unwrapPathPiece
+
+instance PathPiece a => FromHttpApiData (WrappedPathPiece a) where
+  parseUrlPiece = fmap WrappedPathPiece . parseMaybeHttpApiData fromPathPiece
+
+instance PathPiece a => PathPiece (Maybe a) where
+  toPathPiece   = toUrlPiece . fmap WrappedPathPiece
+  fromPathPiece = either (const Nothing) (Just . fmap unwrapPathPiece) . parseUrlPiece
 
 -- | Convert Haskell values to and from sequence of route pieces.
 class PathMultiPiece s where

--- a/test/main.hs
+++ b/test/main.hs
@@ -34,6 +34,7 @@ main = hspec spec
 spec :: Spec
 spec = do
   describe "PathPiece" $ do
+    prop "toPathPiece <=> fromPathPiece ()"           $ \(p :: ())     -> (toPathPiece <=> fromPathPiece) p
     prop "toPathPiece <=> fromPathPiece Bool"         $ \(p :: Bool)   -> (toPathPiece <=> fromPathPiece) p
     prop "toPathPiece <=> fromPathPiece Int"          $ \(p :: Int)    -> (toPathPiece <=> fromPathPiece) p
     prop "toPathPiece <=> fromPathPiece Int8"         $ \(p :: Int8)   -> (toPathPiece <=> fromPathPiece) p


### PR DESCRIPTION
Closes #3.

Also introduces `WrappedPathPiece` which allows to reuse `To/FromHttpApiData` instances while retaining `PathPiece a =>` constraint.