### PR TITLE
Export helper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Unreleased changes
+---
+
+* Export helper functions from `Web.HttpApiData`:
+    * `parseUrlPieceMaybe`, `parseHeaderMaybe`, `parseQueryParamMaybe`
+    * `parseUrlPieceWithPrefix`, `parseHeaderWithPrefix`, `parseQueryParamWithPrefix`
+    * `showTextData`, `readTextData`, `parseBoundedTextData`
+* Fix AMP related warnings
+
 0.1.1
 ---
 

--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -16,7 +16,7 @@ module Web.HttpApiData (
 
   -- * Helpers
   showTextData,
-  readEitherTextData,
+  readTextData,
   parseBoundedCaseInsensitiveTextData,
   parseUrlPieceWithPrefix,
 ) where

--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -17,7 +17,7 @@ module Web.HttpApiData (
   -- * Helpers
   showTextData,
   readTextData,
-  parseBoundedCaseInsensitiveTextData,
+  parseBoundedTextData,
   parseUrlPieceWithPrefix,
 ) where
 

--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -14,11 +14,15 @@ module Web.HttpApiData (
   parseHeaderMaybe,
   parseQueryParamMaybe,
 
-  -- * Helpers
+  -- * Prefix parsers
+  parseUrlPieceWithPrefix,
+  parseHeaderWithPrefix,
+  parseQueryParamWithPrefix,
+
+  -- * Other helpers
   showTextData,
   readTextData,
   parseBoundedTextData,
-  parseUrlPieceWithPrefix,
 ) where
 
 import Web.HttpApiData.Internal

--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -8,6 +8,17 @@ module Web.HttpApiData (
   -- * Classes
   ToHttpApiData (..),
   FromHttpApiData (..),
+
+  -- * @'Maybe'@ parsers
+  parseUrlPieceMaybe,
+  parseHeaderMaybe,
+  parseQueryParamMaybe,
+
+  -- * Helpers
+  showTextData,
+  readEitherTextData,
+  parseBoundedCaseInsensitiveTextData,
+  parseUrlPieceWithPrefix,
 ) where
 
 import Web.HttpApiData.Internal

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -215,10 +215,6 @@ parseBoundedTextData = parseMaybeTextData (flip lookup values . T.toLower)
     values = map (showTextData &&& id) [minBound..maxBound :: a]
 
 -- | Parse URL piece using @'Read'@ instance.
-readMaybeTextData :: Read a => Text -> Maybe a
-readMaybeTextData = readMaybe . T.unpack
-
--- | Parse URL piece using @'Read'@ instance.
 --
 -- Use for types which do not involve letters:
 --
@@ -233,7 +229,7 @@ readMaybeTextData = readMaybe . T.unpack
 --
 -- See @'parseBoundedTextData'@.
 readTextData :: Read a => Text -> Either Text a
-readTextData = parseMaybeTextData readMaybeTextData
+readTextData = parseMaybeTextData (readMaybe . T.unpack)
 
 -- | Run @'Reader'@ as HTTP API data parser.
 runReader :: Reader a -> Text -> Either Text a

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -9,7 +9,9 @@
 -- such as URL pieces, headers and query parameters.
 module Web.HttpApiData.Internal where
 
+#if __GLASGOW_HASKELL__ < 707
 import Control.Applicative
+#endif
 import Control.Arrow ((&&&))
 
 import Data.Monoid

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -104,7 +104,9 @@ parseMaybeTextData parse input =
     Just val -> Right val
 
 #if USE_TEXT_SHOW
--- | Convert to URL piece using @'TextShow'@ instance.
+-- | /Lower case/.
+--
+-- Convert to URL piece using @'TextShow'@ instance.
 -- The result is always lower cased.
 --
 -- >>> showTextData True
@@ -124,7 +126,9 @@ parseMaybeTextData parse input =
 showTextData :: TextShow a => a -> Text
 showTextData = T.toLower . showt
 #else
--- | Convert to URL piece using @'Show'@ instance.
+-- | /Lower case/.
+--
+-- Convert to URL piece using @'Show'@ instance.
 -- The result is always lower cased.
 --
 -- >>> showTextData True
@@ -144,7 +148,9 @@ showt :: Show a => a -> Text
 showt = T.pack . show
 #endif
 
--- | Parse given text case insensitive and return the rest of the input.
+-- | /Case insensitive/.
+--
+-- Parse given text case insensitive and return the rest of the input.
 --
 -- >>> parseUrlPieceWithPrefix "Just " "just 10" :: Either Text Int
 -- Right 10
@@ -165,7 +171,9 @@ parseUrlPieceWithPrefix pattern input
     (prefix, rest) = T.splitAt (T.length pattern) input
 
 #if USE_TEXT_SHOW
--- | Parse values case insensitively based on @'TextShow'@ instance.
+-- | /Case insensitive/.
+--
+-- Parse values case insensitively based on @'TextShow'@ instance.
 --
 -- >>> parseBoundedTextData "true" :: Either Text Bool
 -- Right True
@@ -185,7 +193,9 @@ parseUrlPieceWithPrefix pattern input
 -- @
 parseBoundedTextData :: forall a. (TextShow a, Bounded a, Enum a) => Text -> Either Text a
 #else
--- | Parse values case insensitively based on @'Show'@ instance.
+-- | /Case insensitive/.
+--
+-- Parse values case insensitively based on @'Show'@ instance.
 --
 -- >>> parseBoundedTextData "true" :: Either Text Bool
 -- Right True

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -167,9 +167,9 @@ parseUrlPieceWithPrefix pattern input
 #if USE_TEXT_SHOW
 -- | Parse values case insensitively based on @'TextShow'@ instance.
 --
--- >>> parseBoundedCaseInsensitiveTextData "true" :: Either Text Bool
+-- >>> parseBoundedTextData "true" :: Either Text Bool
 -- Right True
--- >>> parseBoundedCaseInsensitiveTextData "FALSE" :: Either Text Bool
+-- >>> parseBoundedTextData "FALSE" :: Either Text Bool
 -- Right False
 --
 -- This can be used as a default implementation for enumeration types:
@@ -181,26 +181,26 @@ parseUrlPieceWithPrefix pattern input
 --   showt = genericShowt
 --
 -- instance FromHttpApiData MyData where
---   parseUrlPiece = parseBoundedCaseInsensitiveTextData
+--   parseUrlPiece = parseBoundedTextData
 -- @
-parseBoundedCaseInsensitiveTextData :: forall a. (TextShow a, Bounded a, Enum a) => Text -> Either Text a
+parseBoundedTextData :: forall a. (TextShow a, Bounded a, Enum a) => Text -> Either Text a
 #else
 -- | Parse values case insensitively based on @'Show'@ instance.
 --
--- >>> parseBoundedCaseInsensitiveTextData "true" :: Either Text Bool
+-- >>> parseBoundedTextData "true" :: Either Text Bool
 -- Right True
--- >>> parseBoundedCaseInsensitiveTextData "FALSE" :: Either Text Bool
+-- >>> parseBoundedTextData "FALSE" :: Either Text Bool
 -- Right False
 --
 -- This can be used as a default implementation for enumeration types:
 --
 -- >>> data MyData = Foo | Bar | Baz deriving (Show, Bounded, Enum)
--- >>> instance FromHttpApiData MyData where parseUrlPiece = parseBoundedCaseInsensitiveTextData
+-- >>> instance FromHttpApiData MyData where parseUrlPiece = parseBoundedTextData
 -- >>> parseUrlPiece "foo" :: Either Text MyData
 -- Right Foo
-parseBoundedCaseInsensitiveTextData :: forall a. (Show a, Bounded a, Enum a) => Text -> Either Text a
+parseBoundedTextData :: forall a. (Show a, Bounded a, Enum a) => Text -> Either Text a
 #endif
-parseBoundedCaseInsensitiveTextData = parseMaybeTextData (flip lookup values . T.toLower)
+parseBoundedTextData = parseMaybeTextData (flip lookup values . T.toLower)
   where
     values = map (showTextData &&& id) [minBound..maxBound :: a]
 
@@ -221,7 +221,7 @@ readMaybeTextData = readMaybe . T.unpack
 -- >>> readTextData "true" :: Either Text Bool
 -- Left "could not parse: `true'"
 --
--- See @'parseBoundedCaseInsensitiveTextData'@.
+-- See @'parseBoundedTextData'@.
 readTextData :: Read a => Text -> Either Text a
 readTextData = parseMaybeTextData readMaybeTextData
 
@@ -346,8 +346,8 @@ instance FromHttpApiData Void where
   parseUrlPiece _ = Left "Void cannot be parsed!"
 #endif
 
-instance FromHttpApiData Bool     where parseUrlPiece = parseBoundedCaseInsensitiveTextData
-instance FromHttpApiData Ordering where parseUrlPiece = parseBoundedCaseInsensitiveTextData
+instance FromHttpApiData Bool     where parseUrlPiece = parseBoundedTextData
+instance FromHttpApiData Ordering where parseUrlPiece = parseBoundedTextData
 instance FromHttpApiData Double   where parseUrlPiece = runReader rational
 instance FromHttpApiData Float    where parseUrlPiece = runReader rational
 instance FromHttpApiData Int      where parseUrlPiece = parseBounded (signed decimal)

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -255,7 +255,7 @@ parseBoundedTextData = parseMaybeTextData (flip lookup values . T.toLower)
 -- This parser is case sensitive and will not match @'showTextData'@
 -- in presense of letters:
 --
--- >>> readTextData "true" :: Either Text Bool
+-- >>> readTextData (showTextData True) :: Either Text Bool
 -- Left "could not parse: `true'"
 --
 -- See @'parseBoundedTextData'@.

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -171,14 +171,19 @@ parseUrlPieceWithPrefix pattern input
   where
     (prefix, rest) = T.splitAt (T.length pattern) input
 
+-- $setup
+-- >>> data BasicAuthToken = BasicAuthToken Text deriving (Show)
+-- >>> instance FromHttpApiData BasicAuthToken where parseHeader h = BasicAuthToken <$> parseHeaderWithPrefix "Basic " h; parseQueryParam p = BasicAuthToken <$> parseQueryParam p
+
 -- | Parse given bytestring then parse the rest of the input using @'parseHeader'@.
 --
--- >>> data BasicAuthToken = BasicAuthToken Text deriving (Show)
--- >>> :{
+-- @
+-- data BasicAuthToken = BasicAuthToken Text deriving (Show)
+--
 -- instance FromHttpApiData BasicAuthToken where
---   parseHeader h     = BasicAuthToken <$> parseHeaderWithPrefix "Basic " h
---   parseQueryParam p = BasicAuthToken <$> parseQueryParam p
--- :}
+--   parseHeader h     = BasicAuthToken \<$\> parseHeaderWithPrefix "Basic " h
+--   parseQueryParam p = BasicAuthToken \<$\> parseQueryParam p
+-- @
 --
 -- >>> parseHeader "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" :: Either Text BasicAuthToken
 -- Right (BasicAuthToken "QWxhZGRpbjpvcGVuIHNlc2FtZQ==")

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -247,7 +247,7 @@ parseBounded :: forall a. (Bounded a, Integral a) => Reader Integer -> Text -> E
 parseBounded reader input = do
   n <- runReader reader input
   if (n > h || n < l)
-    then Left  ("out of bounds: `" <> input <> "' (should be between " <> T.pack (show l) <> " and " <> T.pack (show h) <> ")")
+    then Left  ("out of bounds: `" <> input <> "' (should be between " <> showt l <> " and " <> showt h <> ")")
     else Right (fromInteger n)
   where
     l = toInteger (minBound :: a)

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -9,7 +9,7 @@
 -- such as URL pieces, headers and query parameters.
 module Web.HttpApiData.Internal where
 
-#if __GLASGOW_HASKELL__ < 707
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
 #endif
 import Control.Arrow ((&&&))

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -174,7 +174,7 @@ parseUrlPieceWithPrefix pattern input
 -- | Parse given bytestring then parse the rest of the input using @'parseHeader'@.
 --
 -- >>> :{
--- newtype BasicAuthToken = BasicAuthToken Text deriving (Show)
+-- data BasicAuthToken = BasicAuthToken Text deriving (Show)
 -- instance FromHttpApiData BasicAuthToken where
 --   parseHeader h     = BasicAuthToken <$> parseHeaderWithPrefix "Basic " h
 --   parseQueryParam p = BasicAuthToken <$> parseQueryParam p

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -325,13 +325,13 @@ instance (ToHttpApiData a, ToHttpApiData b) => ToHttpApiData (Either a b) where
 -- >>> parseUrlPiece "_" :: Either Text ()
 -- Right ()
 instance FromHttpApiData () where
-  parseUrlPiece "_" = return ()
+  parseUrlPiece "_" = pure ()
   parseUrlPiece s   = defaultParseError s
 
 instance FromHttpApiData Char where
   parseUrlPiece s =
     case T.uncons s of
-      Just (c, s') | T.null s' -> return c
+      Just (c, s') | T.null s' -> pure c
       _                        -> defaultParseError s
 
 -- |
@@ -340,7 +340,7 @@ instance FromHttpApiData Char where
 instance FromHttpApiData Version where
   parseUrlPiece s =
     case reverse (readP_to_S parseVersion (T.unpack s)) of
-      ((x, ""):_) -> return x
+      ((x, ""):_) -> pure x
       _           -> defaultParseError s
 
 #if MIN_VERSION_base(4,8,0)
@@ -387,7 +387,7 @@ instance FromHttpApiData a => FromHttpApiData (Last a)    where parseUrlPiece = 
 -- Right (Just 123)
 instance FromHttpApiData a => FromHttpApiData (Maybe a) where
   parseUrlPiece s
-    | T.toLower (T.take 7 s) == "nothing" = return Nothing
+    | T.toLower (T.take 7 s) == "nothing" = pure Nothing
     | otherwise                           = Just <$> parseUrlPieceWithPrefix "Just " s
 
 -- |

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -209,8 +209,21 @@ readMaybeTextData :: Read a => Text -> Maybe a
 readMaybeTextData = readMaybe . T.unpack
 
 -- | Parse URL piece using @'Read'@ instance.
-readEitherTextData :: Read a => Text -> Either Text a
-readEitherTextData = parseMaybeTextData readMaybeTextData
+--
+-- Use for types which do not involve letters:
+--
+-- >>> readTextData "1991-06-02" :: Either Text Day
+-- Right 1991-06-02
+--
+-- This parser is case sensitive and will not match @'showTextData'@
+-- in presense of letters:
+--
+-- >>> readTextData "true" :: Either Text Bool
+-- Left "could not parse: `true'"
+--
+-- See @'parseBoundedCaseInsensitiveTextData'@.
+readTextData :: Read a => Text -> Either Text a
+readTextData = parseMaybeTextData readMaybeTextData
 
 -- | Run @'Reader'@ as HTTP API data parser.
 runReader :: Reader a -> Text -> Either Text a
@@ -355,7 +368,7 @@ instance FromHttpApiData L.Text   where parseUrlPiece = Right . L.fromStrict
 -- |
 -- >>> toGregorian <$> parseUrlPiece "2016-12-01"
 -- Right (2016,12,1)
-instance FromHttpApiData Day      where parseUrlPiece = readEitherTextData
+instance FromHttpApiData Day      where parseUrlPiece = readTextData
 
 instance FromHttpApiData All where parseUrlPiece = fmap All . parseUrlPiece
 instance FromHttpApiData Any where parseUrlPiece = fmap Any . parseUrlPiece

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -24,7 +24,7 @@ import Data.Text.Read (signed, decimal, rational, Reader)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as L
 
-import Data.Time (Day)
+import Data.Time
 import Data.Version
 
 #if MIN_VERSION_base(4,8,0)
@@ -37,9 +37,6 @@ import Text.ParserCombinators.ReadP (readP_to_S)
 #if USE_TEXT_SHOW
 import TextShow (TextShow, showt)
 #endif
-
--- $setup
--- >>> import Data.Time
 
 -- | Convert value to HTTP API data.
 class ToHttpApiData a where

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -190,7 +190,7 @@ parseUrlPieceWithPrefix pattern input
 -- instance FromHttpApiData MyData where
 --   parseUrlPiece = parseBoundedTextData
 -- @
-parseBoundedTextData :: forall a. (TextShow a, Bounded a, Enum a) => Text -> Either Text a
+parseBoundedTextData :: (TextShow a, Bounded a, Enum a) => Text -> Either Text a
 #else
 -- | /Case insensitive/.
 --
@@ -207,11 +207,11 @@ parseBoundedTextData :: forall a. (TextShow a, Bounded a, Enum a) => Text -> Eit
 -- >>> instance FromHttpApiData MyData where parseUrlPiece = parseBoundedTextData
 -- >>> parseUrlPiece "foo" :: Either Text MyData
 -- Right Foo
-parseBoundedTextData :: forall a. (Show a, Bounded a, Enum a) => Text -> Either Text a
+parseBoundedTextData :: (Show a, Bounded a, Enum a) => Text -> Either Text a
 #endif
 parseBoundedTextData = parseMaybeTextData (flip lookup values . T.toLower)
   where
-    values = map (showTextData &&& id) [minBound..maxBound :: a]
+    values = map (showTextData &&& id) [minBound..maxBound]
 
 -- | Parse URL piece using @'Read'@ instance.
 --

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -173,8 +173,8 @@ parseUrlPieceWithPrefix pattern input
 
 -- | Parse given bytestring then parse the rest of the input using @'parseHeader'@.
 --
+-- >>> data BasicAuthToken = BasicAuthToken Text deriving (Show)
 -- >>> :{
--- data BasicAuthToken = BasicAuthToken Text deriving (Show)
 -- instance FromHttpApiData BasicAuthToken where
 --   parseHeader h     = BasicAuthToken <$> parseHeaderWithPrefix "Basic " h
 --   parseQueryParam p = BasicAuthToken <$> parseQueryParam p

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -17,7 +17,6 @@ import Test.Hspec.QuickCheck(prop)
 import Test.QuickCheck
 
 import Web.HttpApiData
-import Web.HttpApiData.Internal
 
 instance Arbitrary T.Text where
   arbitrary = T.pack <$> arbitrary


### PR DESCRIPTION
Closes #18.

What's in:
- re-exported functions listed in #18 from `Web.HttpApiData`;
- renamed `readEitherTextData` to `readTextData`;
- renamed `parseBoundedCaseInsensitiveTextData` to `parseBoundedTextData`;
- added some extra documentation for helpers.

I am going to make a few more cleanups and include this in `v0.2`.