### PR TITLE
Helpers for multiple URL pieces and query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased changes
+---
+
+* Add helpers for multiple URL pieces and query params:
+    * `toUrlPieces`, `parseUrlPieces`
+    * `toQueryParams`, `parseQueryParams`
+
 0.2
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,22 +11,24 @@ Booleans:
 
 ```
 >>> toUrlPiece True
-"True"
->>> parseUrlPiece "False" :: Either Text Bool
+"true"
+>>> parseUrlPiece "false" :: Either Text Bool
 Right False
->>> parseUrlPiece "something else" :: Either Text Bool
-Left "could not parse: `something else'"
+>>> parseUrlPieces ["true", "false", "undefined"] :: Either Text [Bool]
+Left "could not parse: `undefined'"
 ```
 
 Numbers:
 
 ```
->>> toUrlPiece 45.2
+>>> toQueryParam 45.2
 "45.2"
->>> parseUrlPiece "452" :: Either Text Int
+>>> parseQueryParam "452" :: Either Text Int
 Right 452
->>> parseUrlPiece "256" :: Either Text Int8
-Left "out of bounds: `256' (should be between -128 and 127)"
+>>> toQueryParams [1..5]
+["1","2","3","4","5"]
+>>> parseQueryParams ["127", "255"] :: Either Text [Int8]
+Left "out of bounds: `255' (should be between -128 and 127)"
 ```
 
 Strings:

--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -23,6 +23,10 @@ module Web.HttpApiData (
   toUrlPieces,
   parseUrlPieces,
 
+  -- * Multiple query params
+  toQueryParams,
+  parseQueryParams,
+
   -- * Other helpers
   showTextData,
   readTextData,

--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -53,17 +53,19 @@ import Web.HttpApiData.Internal
 -- "true"
 -- >>> parseUrlPiece "false" :: Either Text Bool
 -- Right False
--- >>> parseUrlPiece "something else" :: Either Text Bool
--- Left "could not parse: `something else'"
+-- >>> parseUrlPieces ["true", "false", "undefined"] :: Either Text [Bool]
+-- Left "could not parse: `undefined'"
 --
 -- Numbers:
 --
--- >>> toUrlPiece 45.2
+-- >>> toQueryParam 45.2
 -- "45.2"
--- >>> parseUrlPiece "452" :: Either Text Int
+-- >>> parseQueryParam "452" :: Either Text Int
 -- Right 452
--- >>> parseUrlPiece "256" :: Either Text Int8
--- Left "out of bounds: `256' (should be between -128 and 127)"
+-- >>> toQueryParams [1..5]
+-- ["1","2","3","4","5"]
+-- >>> parseQueryParams ["127", "255"] :: Either Text [Int8]
+-- Left "out of bounds: `255' (should be between -128 and 127)"
 --
 -- Strings:
 --
@@ -78,3 +80,4 @@ import Web.HttpApiData.Internal
 -- "2015-10-03"
 -- >>> toGregorian <$> parseQueryParam "2016-12-01"
 -- Right (2016,12,1)
+

--- a/Web/HttpApiData.hs
+++ b/Web/HttpApiData.hs
@@ -19,6 +19,10 @@ module Web.HttpApiData (
   parseHeaderWithPrefix,
   parseQueryParamWithPrefix,
 
+  -- * Multiple URL pieces
+  toUrlPieces,
+  parseUrlPieces,
+
   -- * Other helpers
   showTextData,
   readTextData,

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -11,7 +11,7 @@ module Web.HttpApiData.Internal where
 
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
-import Data.Traversable (traverse)
+import Data.Traversable (Traversable(traverse))
 #endif
 import Control.Arrow ((&&&))
 

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -71,6 +71,22 @@ class FromHttpApiData a where
   parseQueryParam :: Text -> Either Text a
   parseQueryParam = parseUrlPiece
 
+-- | Convert multiple values to a list of URL pieces.
+--
+-- >>> toUrlPieces [1, 2, 3]
+-- ["1","2","3"]
+toUrlPieces :: (Functor t, ToHttpApiData a) => t a -> t Text
+toUrlPieces = fmap toUrlPiece
+
+-- | Parse multiple URL pieces.
+--
+-- >>> parseUrlPieces ["true", "false"] :: Either Text [Bool]
+-- Right [True,False]
+-- >>> parseUrlPieces ["123", "hello", "world"] :: Either Text [Int]
+-- Left "input does not start with a digit"
+parseUrlPieces :: (Traversable t, FromHttpApiData a) => t Text -> Either Text (t a)
+parseUrlPieces = traverse parseUrlPiece
+
 -- | Parse URL path piece in a @'Maybe'@.
 --
 -- >>> parseUrlPieceMaybe "12" :: Maybe Int

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -84,7 +84,7 @@ toUrlPieces = fmap toUrlPiece
 -- >>> parseUrlPieces ["true", "false"] :: Either Text [Bool]
 -- Right [True,False]
 -- >>> parseUrlPieces ["123", "hello", "world"] :: Either Text [Int]
--- Left "input does not start with a digit"
+-- Left "could not parse: `hello' (input does not start with a digit)"
 parseUrlPieces :: (Traversable t, FromHttpApiData a) => t Text -> Either Text (t a)
 parseUrlPieces = traverse parseUrlPiece
 
@@ -304,7 +304,7 @@ readTextData = parseMaybeTextData (readMaybe . T.unpack)
 runReader :: Reader a -> Text -> Either Text a
 runReader reader input =
   case reader input of
-    Left err          -> Left (T.pack err)
+    Left err          -> Left ("could not parse: `" <> input <> "' (" <> T.pack err <> ")")
     Right (x, rest)
       | T.null rest -> Right x
       | otherwise   -> defaultParseError input

--- a/Web/HttpApiData/Internal.hs
+++ b/Web/HttpApiData/Internal.hs
@@ -11,6 +11,7 @@ module Web.HttpApiData.Internal where
 
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+import Data.Traversable (traverse)
 #endif
 import Control.Arrow ((&&&))
 
@@ -86,6 +87,22 @@ toUrlPieces = fmap toUrlPiece
 -- Left "input does not start with a digit"
 parseUrlPieces :: (Traversable t, FromHttpApiData a) => t Text -> Either Text (t a)
 parseUrlPieces = traverse parseUrlPiece
+
+-- | Convert multiple values to a list of query parameter values.
+--
+-- >>> toQueryParams [fromGregorian 2015 10 03, fromGregorian 2015 12 01]
+-- ["2015-10-03","2015-12-01"]
+toQueryParams :: (Functor t, ToHttpApiData a) => t a -> t Text
+toQueryParams = fmap toQueryParam
+
+-- | Parse multiple query parameters.
+--
+-- >>> parseQueryParams ["1", "2", "3"] :: Either Text [Int]
+-- Right [1,2,3]
+-- >>> parseQueryParams ["64", "128", "256"] :: Either Text [Word8]
+-- Left "out of bounds: `256' (should be between 0 and 255)"
+parseQueryParams :: (Traversable t, FromHttpApiData a) => t Text -> Either Text (t a)
+parseQueryParams = traverse parseQueryParam
 
 -- | Parse URL path piece in a @'Maybe'@.
 --


### PR DESCRIPTION
What's in:
- `toUrlPieces`, `parseUrlPieces`;
- `toQueryParams`, `parseQueryParams`;
- improved parse error message for numbers.

Types for `to/parseUrlPieces` and `to/parseQueryParams` are general (using `Functor` and `Traversable` classes instead of `[a]`). This might be useful for list-like types like `NonEmpty`.