### PR TITLE
Make parseHeader total (instead of failing when decoding)

### DIFF
--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -26,6 +26,7 @@ library
                    , bytestring
                    , time
                    , time-locale-compat >=0.1.1.0 && <0.2
+                   , either
     if flag(use-text-show)
       cpp-options: -DUSE_TEXT_SHOW
       build-depends: text-show        >= 2
@@ -46,6 +47,7 @@ test-suite spec
                    , http-api-data
                    , text
                    , time
+                   , bytestring
 
 test-suite doctest
     build-depends:    base, doctest, Glob

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,6 +10,7 @@ import Data.Word
 import Data.Time
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as L
+import qualified Data.ByteString as BS
 import Data.Version
 
 import Test.Hspec
@@ -125,4 +126,7 @@ spec = do
   it "bounds checking works" $ do
     parseUrlPieceMaybe (T.pack "256") `shouldBe` (Nothing :: Maybe Int8)
     parseUrlPieceMaybe (T.pack "-10") `shouldBe` (Nothing :: Maybe Word)
+
+  it "invalid utf8 is handled" $ do
+    parseHeaderMaybe (BS.pack [128]) `shouldBe` (Nothing :: Maybe T.Text)
 


### PR DESCRIPTION
current behavior:
```
> parseHeader "\250\250" :: Either Text Text
Right "*** Exception: Cannot decode byte '\xfa': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream
```

With my patch:
```
> parseHeader "\250\250" :: Either Text Text
Left "Cannot decode byte '\\xfa': Data.Text.Internal.Encoding.decodeUtf8: Invalid UTF-8 stream"
```