### PR TITLE
Export `Form` datatype from the `Web.FormUrlEncoded` module.

### DIFF
--- a/src/Web/FormUrlEncoded.hs
+++ b/src/Web/FormUrlEncoded.hs
@@ -9,6 +9,9 @@ module Web.FormUrlEncoded (
   ToFormKey(..),
   FromFormKey(..),
 
+  -- * Abstract 'Form' type
+  Form,
+
   -- * Encoding and decoding @'Form'@s
   urlEncodeAsForm,
   urlDecodeAsForm,


### PR DESCRIPTION
This commit exports the abstract `Form` datatype from the
`Web.FormUrlEncoded` module.

Closes #36.