### PR TITLE
export Form data constructor from Web.FormUrlEncoded

### DIFF
--- a/src/Web/FormUrlEncoded.hs
+++ b/src/Web/FormUrlEncoded.hs
@@ -9,8 +9,8 @@ module Web.FormUrlEncoded (
   ToFormKey(..),
   FromFormKey(..),
 
-  -- * Abstract 'Form' type
-  Form,
+  -- * 'Form' type
+  Form(..),
 
   -- * Encoding and decoding @'Form'@s
   urlEncodeAsForm,


### PR DESCRIPTION
While upgrading servant i've encountered an import issue. To have my own instances of `ToForm`, i need to construct `Form` objects and right now it looks like i need to import `Web.Internal.FormUrlEncoded`. This way you force your users to depend on internal modules and that's why i consider it bad import hygiene.

I've seen the `IsList Form` instance, but surely it's not the only one way to construct it.

P.S. putting module `FormUrlEncoded` inside `Internal` and not the other way around makes less sense to me than calling it `Web.FormUrlEncoded.Internal` and re-exporting all the good stuff from `Web.FormUrlEncoded`. I mean - what is `Web.Internal`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fizruk/http-api-data/40)
<!-- Reviewable:end -->
