### PR TITLE
Add LenientData

### DIFF
--- a/src/Web/HttpApiData.hs
+++ b/src/Web/HttpApiData.hs
@@ -35,6 +35,9 @@ module Web.HttpApiData (
   parseBoundedEnumOfI,
   parseBoundedTextData,
 
+  -- * Lenient data
+  LenientData (..),
+
   -- * Other helpers
   showTextData,
   readTextData,


### PR DESCRIPTION
Motivated by `servant` making parameter parsing fail.

Is it ok to define `ToHttpApiData` instance with `toQueryParam = either (const "") toQueryParam . getLenientData`, i.e. serialising `Left` to an empty string?