### PR TITLE
Bump doctest upper bound

### DIFF
--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -88,7 +88,7 @@ test-suite doctests
   build-depends:
     base,
     directory >= 1.0,
-    doctest >= 0.11 && <0.12,
+    doctest >= 0.11 && <0.14,
     filepath
   default-language: Haskell2010
   hs-source-dirs:   test


### PR DESCRIPTION
Tests pass with doctest-0.13.0.