### PR TITLE
Allow http-types-0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/01-index.tar
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/01-index.tar.idx
 
-  - rm -fv $HOME/.cabal/packages/head.hackage
+  - rm -rfv $HOME/.cabal/packages/head.hackage
 
 matrix:
   include:
@@ -97,14 +97,14 @@ script:
 
   # build & run tests, build benchmarks
   - cabal new-build -w ${HC} ${TEST} ${BENCH} all
-  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
+  - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
   # cabal check
   - (cd http-api-data-* && cabal check)
 
   # haddock
   - rm -rf ./dist-newstyle
-  - if $HADDOCK; then cabal new-haddock -w ${HC} --disable-tests --disable-benchmarks all; else echo "Skipping haddock generation";fi
+  - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
 
   - if [ $HCNUMVER -eq 70804 ]; then cabal new-build -w ${HC} --disable-tests --disable-benchmarks --constraint='attoparsec ==0.13.0.1' --constraint='attoparsec-iso8601 ==1.0.0.0' --constraint='bytestring ==0.10.4.0' --constraint='containers ==0.5.5.1' --constraint='hashable ==1.1.2.4' --constraint='http-types ==0.8.6' --constraint='text ==1.1.1.3' --constraint='time ==1.4.2' --constraint='time-local-compat ==0.1.1.0' --constraint='unordered-containers ==0.2.5.0' --constraint='uri-bytestring ==0.1.7' --constraint='uuid-types ==1.0.2' all; else echo skipping...; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.7.2
+---
+
+* Allow http-types-0.12
+* .cabal file adjustments
+
 0.3.7.1
 ---
 

--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -1,5 +1,5 @@
 name:            http-api-data
-version:         0.3.7.1
+version:         0.3.7.2
 license:         BSD3
 license-file:    LICENSE
 author:          Nickolay Kudasov <nickolay.kudasov@gmail.com>
@@ -29,7 +29,7 @@ custom-setup
   setup-depends:
     base >= 4.7 && <4.11,
     Cabal >= 1.18 && <2.1,
-    cabal-doctest >=1.0.1 && <1.1
+    cabal-doctest >=1.0.6 && <1.1
 
 flag use-text-show
   description: Use text-show library for efficient ToHttpApiData implementations.
@@ -45,7 +45,7 @@ library
                    , bytestring            >= 0.10.4.0 && < 0.11
                    , containers            >= 0.5.5.1  && < 0.6
                    , hashable              >= 1.1.2.4  && < 1.3
-                   , http-types            >= 0.8.6    && < 0.12
+                   , http-types            >= 0.8.6    && < 0.13
                    , text                  >= 1.1.1.3  && < 1.3
                    , time                  >= 1.4.2    && < 1.9
                    , time-locale-compat    >= 0.1.1.0  && < 0.2
@@ -73,10 +73,10 @@ test-suite spec
     hs-source-dirs: test
     ghc-options:   -Wall
     default-language: Haskell2010
-    build-tool-depends: hspec-discover:hspec-discover
+    build-tool-depends: hspec-discover:hspec-discover >= 2.4.7 && <2.5
     build-depends:   HUnit
-                   , hspec >= 1.3
-                   , base >= 4 && < 5
+                   , hspec >= 2.4.7
+                   , base
                    , bytestring
                    , QuickCheck >=2.9
                    , quickcheck-instances >= 0.3.12


### PR DESCRIPTION
Let's allow `time-1.9` when it's bundled with GHC, not we cannot test it doesn't break us.