### PR TITLE
Remove dependency on uri-bytestring and use functions from http-types instead

### DIFF
--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -51,7 +51,6 @@ library
                    , time                  >= 1.4.2    && < 1.9
                    , time-locale-compat    >= 0.1.1.0  && < 0.2
                    , unordered-containers  >= 0.2.6.0  && < 0.3
-                   , uri-bytestring        >= 0.1.7    && < 0.4
                    , uuid-types            >= 1.0.2    && <1.1
     if !impl(ghc >= 8.0)
       build-depends: semigroups            >= 0.16     && < 0.19

--- a/src/Web/Internal/FormUrlEncoded.hs
+++ b/src/Web/Internal/FormUrlEncoded.hs
@@ -60,7 +60,7 @@ import Numeric.Natural
 import           GHC.Exts                   (IsList (..), Constraint)
 import           GHC.Generics
 import           GHC.TypeLits
-import           URI.ByteString             (urlEncodeQuery, urlDecodeQuery)
+import           Network.HTTP.Types.URI     (urlEncodeBuilder, urlDecode)
 
 import Web.Internal.HttpApiData
 
@@ -543,7 +543,7 @@ urlEncodeFormStable = urlEncodeParams . sortOn fst . toList
 urlEncodeParams :: [(Text, Text)] -> BSL.ByteString
 urlEncodeParams = toLazyByteString . mconcat . intersperse (shortByteString "&") . map encodePair
   where
-    escape = urlEncodeQuery . Text.encodeUtf8
+    escape = urlEncodeBuilder True . Text.encodeUtf8
 
     encodePair (k, "") = escape k
     encodePair (k, v) = escape k <> shortByteString "=" <> escape v
@@ -590,7 +590,7 @@ urlDecodeParams bs = traverse parsePair pairs
   where
     pairs = map (BSL8.split '=') (BSL8.split '&' bs)
 
-    unescape = Text.decodeUtf8With lenientDecode . urlDecodeQuery . BSL.toStrict
+    unescape = Text.decodeUtf8With lenientDecode . urlDecode True . BSL.toStrict
 
     parsePair p =
       case map unescape p of


### PR DESCRIPTION
The functions used from `uri-bytestring` are mostly vendored from `http-types`, so this extra dependency is not needed. As a bonus, by removing `uri-bytestring` from the dependencies means you no longer have to compile `th-lifted-instances`, which means that `http-api-data` is now free from TemplateHaskell, and much easier to cross-compile.