### PR TITLE
Fix documentation of parseBoundedEnumOf

### DIFF
--- a/src/Web/Internal/HttpApiData.hs
+++ b/src/Web/Internal/HttpApiData.hs
@@ -334,7 +334,7 @@ lookupBoundedEnumOf f = flip lookup (map (f &&& id) [minBound..maxBound])
 -- >>> parseBoundedEnumOf toUrlPiece "true" :: Either Text Bool
 -- Right True
 --
--- For case sensitive parser see 'parseBoundedEnumOfI'.
+-- For case insensitive parser see 'parseBoundedEnumOfI'.
 parseBoundedEnumOf :: (Bounded a, Enum a) => (a -> Text) -> Text -> Either Text a
 parseBoundedEnumOf = parseMaybeTextData . lookupBoundedEnumOf
 


### PR DESCRIPTION
Just fixing a small typo in the doc here:
https://hackage.haskell.org/package/http-api-data-0.4.1.1/docs/Web-HttpApiData.html#v:parseBoundedEnumOf