### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -44,7 +44,7 @@ library
 
     -- GHC bundled
     build-depends:   base                  >= 4.7      && < 4.15
-                   , bytestring            >= 0.10.4.0 && < 0.11
+                   , bytestring            >= 0.10.4.0 && < 0.12
                    , containers            >= 0.5.5.1  && < 0.7
                    , text                  >= 1.2.3.0  && < 1.3
                    , transformers          >= 0.3      && < 0.6


### PR DESCRIPTION
Tested using 
```cabal
packages: .
tests: true

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

source-repository-package
  type: git
  location: https://github.com/haskell/attoparsec

allow-newer:
  uuid-types:bytestring
```