### PR TITLE
Escape reserved symbols in default implementation of toEncodedUrlPiece

### DIFF
--- a/src/Web/Internal/HttpApiData.hs
+++ b/src/Web/Internal/HttpApiData.hs
@@ -96,7 +96,7 @@ class ToHttpApiData a where
   -- The default definition uses 'H.encodePathSegmentsRelative',
   -- but this may be overriden with a more efficient version.
   toEncodedUrlPiece :: a -> BS.Builder
-  toEncodedUrlPiece = H.encodePathSegmentsRelative . (:[]) . toUrlPiece
+  toEncodedUrlPiece = H.urlEncodeBuilder True . encodeUtf8 . toUrlPiece
 
   -- | Convert to HTTP header value.
   toHeader :: a -> ByteString
@@ -514,7 +514,7 @@ instance ToHttpApiData DayOfWeek where
 
   toEncodedUrlPiece = unsafeToEncodedUrlPiece
 
--- | 
+-- |
 -- >>> toUrlPiece Q4
 -- "q4"
 instance ToHttpApiData QuarterOfYear where
@@ -865,5 +865,3 @@ runAtto :: Atto.Parser a -> Text -> Either Text a
 runAtto p t = case Atto.parseOnly (p <* Atto.endOfInput) t of
     Left err -> Left (T.pack err)
     Right x  -> Right x
-
-


### PR DESCRIPTION
Hi) I was investigating an issue with our application where filters wouldn't work correctly if the user enters a plus sign. First I noticed that at some point HTTP request is sent to an endpoint that contains unescaped plus signs, for example if user types `"foo+bar@gmail.com"` the request would be like `"GET /?search_by=foo+bar@gmail.com"` (with plus symbol unescaped). We are using servant and servant-client libraries between our backends, I dug deeper into servant-client internals and everything points to default implementation of `toEncodedUrlPiece` method being the root cause of the problem. 

Actually the real source might be further down the stack in the `http-types` package where I also going to send a pull request, but I suggest you to merge this changes here as well. Currently `toEncodedUrlPiece` uses `encodePathSegmentsRelative` which under the hood calls [`urlEncodeBuilder False`](https://hackage.haskell.org/package/http-types-0.12.3/docs/src/Network.HTTP.Types.URI.html#urlEncodeBuilder)  which is wrong, because it doesn't escape characters `:@&=+$,` and the documentation for toEncodedUrlPiece clearly states that it should escape all special characters 