### PR TITLE
Use text-iso8601 for parsing and rendering time types

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.4
+# version: 0.16.5
 #
-# REGENDATA ("0.16.4",["github","cabal.project"])
+# REGENDATA ("0.16.5",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -75,11 +75,6 @@ jobs:
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
             setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
@@ -217,8 +212,8 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_http_api_data}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package http-api-data" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package http-api-data" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(http-api-data)$/; }' >> cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+0.6
+---
+
+* Use [`text-iso8601`](https://hackage.haskell.org/package/text-iso8601)
+  to parse and serialise `time` types. (Instead of `attoparsec-iso8601`).
+  Due this change some formats are slightly changed:
+
+  - Space between timezone is not accepted
+  - Timezone offset can be between -23:59..23:59
+  - Timezone offset is output with colon between hours and minutes
+
+* Require at least GHC-8.2
+
 0.5.1
 -----
 

--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -1,6 +1,6 @@
-cabal-version:   >= 1.10
+cabal-version:   1.12
 name:            http-api-data
-version:         0.5.1
+version:         0.6
 
 synopsis:        Converting to/from HTTP API data like URL pieces, headers and query parameters.
 category:        Web
@@ -23,7 +23,6 @@ extra-source-files:
   README.md
 
 tested-with:
-  GHC==8.0.2,
   GHC==8.2.2,
   GHC==8.4.4,
   GHC==8.6.5,
@@ -43,20 +42,19 @@ library
     hs-source-dirs: src/
 
     -- GHC bundled
-    build-depends:   base                  >= 4.9      && < 4.19
-                   , bytestring            >= 0.10.8.1 && < 0.12
-                   , containers            >= 0.5.7.1  && < 0.7
+    build-depends:   base                  >= 4.10.1.0 && < 4.19
+                   , bytestring            >= 0.10.8.2 && < 0.12
+                   , containers            >= 0.5.10.2 && < 0.7
                    , text                  >= 1.2.3.0  && < 1.3 || >=2.0 && <2.1
                    , transformers          >= 0.5.2.0  && < 0.7
 
     -- other-dependencies
     build-depends:
-                     attoparsec            >= 0.13.2.2 && < 0.15
-                   , attoparsec-iso8601    >= 1.1.0.0  && < 1.2
-                   , base-compat           >= 0.10.5   && < 0.14
+                     base-compat           >= 0.10.5   && < 0.14
                    , cookie                >= 0.4.3    && < 0.5
                    , hashable              >= 1.2.7.0  && < 1.5
                    , http-types            >= 0.12.3   && < 0.13
+                   , text-iso8601          >= 0.1      && < 0.2
                    , tagged                >= 0.8.5    && < 0.9
                    , time-compat           >= 1.9.5    && < 1.10
                    , unordered-containers  >= 0.2.10.0 && < 0.3


### PR DESCRIPTION
Drop dependency on attoparsec-iso8601 and attoparsec.