### PR TITLE
Allow text-2.1

### DIFF
--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -45,7 +45,7 @@ library
     build-depends:   base                  >= 4.10.1.0 && < 4.19
                    , bytestring            >= 0.10.8.2 && < 0.12
                    , containers            >= 0.5.10.2 && < 0.7
-                   , text                  >= 1.2.3.0  && < 1.3 || >=2.0 && <2.1
+                   , text                  >= 1.2.3.0  && < 1.3 || >=2.0 && <2.2
                    , transformers          >= 0.5.2.0  && < 0.7
 
     -- other-dependencies


### PR DESCRIPTION
Tested using:

```
cabal test -w ghc-9.6.2 -c 'text>=2.1'
```