### PR TITLE
Prevent HashDOS

### DIFF
--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -57,7 +57,6 @@ library
                    , text-iso8601          >= 0.1.1    && < 0.2
                    , tagged                >= 0.8.8    && < 0.9
                    , time-compat           >= 1.9.5    && < 1.10
-                   , unordered-containers  >= 0.2.20   && < 0.3
                    , uuid-types            >= 1.0.6    && < 1.1
 
     if flag(use-text-show)
@@ -91,7 +90,7 @@ test-suite spec
                    , http-api-data
                    , text
                    , time-compat
-                   , unordered-containers
+                   , containers
                    , uuid-types
 
     build-depends:   HUnit                >= 1.6.0.0  && <1.7

--- a/src/Web/Internal/HttpApiData.hs
+++ b/src/Web/Internal/HttpApiData.hs
@@ -28,11 +28,10 @@ import qualified Data.Fixed                   as F
 import           Data.Functor.Identity        (Identity(Identity))
 import           Data.Int                     (Int16, Int32, Int64, Int8)
 import           Data.Kind                    (Type)
-import qualified Data.Map                     as Map
+import qualified Data.Map.Strict              as Map
 import           Data.Monoid                  (All (..), Any (..), Dual (..),
                                                First (..), Last (..),
                                                Product (..), Sum (..))
-import           Data.Semigroup               (Semigroup (..))
 import qualified Data.Semigroup               as Semi
 import           Data.Tagged                  (Tagged (..))
 import           Data.Text                    (Text)

--- a/test/Web/Internal/FormUrlEncodedSpec.hs
+++ b/test/Web/Internal/FormUrlEncodedSpec.hs
@@ -4,7 +4,7 @@ module Web.Internal.FormUrlEncodedSpec (spec) where
 
 import Control.Monad ((<=<))
 import qualified Data.ByteString.Lazy.Char8 as BSL
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict            as Map
 import Data.Text (Text, unpack)
 import Test.Hspec
 import Test.QuickCheck
@@ -27,13 +27,13 @@ genericSpec = describe "Default (generic) instances" $ do
 
     it "contains the record names" $ property $ \(x :: SimpleRec) -> do
       let f = unForm $ toForm x
-      HashMap.member "rec1" f `shouldBe` True
-      HashMap.member "rec2" f `shouldBe` True
+      Map.member "rec1" f `shouldBe` True
+      Map.member "rec2" f `shouldBe` True
 
     it "contains the correct record values" $ property $ \(x :: SimpleRec) -> do
       let f = unForm $ toForm x
-      HashMap.lookup "rec1" f `shouldBe` Just [rec1 x]
-      (parseQueryParams <$> HashMap.lookup "rec2" f) `shouldBe` Just (Right [rec2 x])
+      Map.lookup "rec1" f `shouldBe` Just [rec1 x]
+      (parseQueryParams <$> Map.lookup "rec2" f) `shouldBe` Just (Right [rec2 x])
 
   context "FromForm" $ do
 

--- a/test/Web/Internal/TestInstances.hs
+++ b/test/Web/Internal/TestInstances.hs
@@ -8,6 +8,7 @@ module Web.Internal.TestInstances
    , NoEmptyKeyForm(..)
    ) where
 
+import           Control.Applicative  -- for ghc < 9.6
 import           Data.Char
 import qualified Data.Map.Strict      as Map
 import qualified Data.Text            as T

--- a/test/Web/Internal/TestInstances.hs
+++ b/test/Web/Internal/TestInstances.hs
@@ -8,9 +8,8 @@ module Web.Internal.TestInstances
    , NoEmptyKeyForm(..)
    ) where
 
-import           Control.Applicative
 import           Data.Char
-import qualified Data.HashMap.Strict  as HashMap
+import qualified Data.Map.Strict      as Map
 import qualified Data.Text            as T
 import           Data.Time.Compat
 import           GHC.Exts             (fromList)
@@ -63,4 +62,4 @@ newtype NoEmptyKeyForm =
 instance Arbitrary NoEmptyKeyForm where
   arbitrary = NoEmptyKeyForm . removeEmptyKeys <$> arbitrary
     where
-      removeEmptyKeys (Form m) = Form (HashMap.delete "" m)
+      removeEmptyKeys (Form m) = Form (Map.delete "" m)


### PR DESCRIPTION
Addresses #116 by removing the `HashMap` implementation entirely. It's done under the assumption that a library aiming at handling http data is always exposed to untrusted input, and hence there are no "safe" use cases for `HashMap` in its current vulnerable form.