### PR TITLE
Upgrade CI for GHC 9.14.1 and fix related errors

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250330
+# version: 0.19.20260102
 #
-# REGENDATA ("0.19.20250330",["github","cabal.project"])
+# REGENDATA ("0.19.20260102",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -32,6 +35,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -95,8 +103,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1-p1 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1-p1 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -121,7 +129,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -149,6 +157,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -174,14 +194,14 @@ jobs:
       - name: install cabal-docspec
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20240703/cabal-docspec-0.0.0.20240703-x86_64-linux.xz > cabal-docspec.xz
-          echo '48bf3b7fd2f7f0caa6162afee57a755be8523e7f467b694900eb420f5f9a7b76  cabal-docspec.xz' | sha256sum -c -
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20250606/cabal-docspec-0.0.0.20250606-x86_64-linux.xz > cabal-docspec.xz
+          echo 'cc20bb5c19501b42bde77556bc419c7c0a5c8d1eb65663024d8a4e4c868bef25  cabal-docspec.xz' | sha256sum -c -
           xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
           rm -f cabal-docspec.xz
           chmod a+x $HOME/.cabal/bin/cabal-docspec
           cabal-docspec --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -206,9 +226,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_http_api_data}" >> cabal.project
           echo "package http-api-data" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package http-api-data" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package http-api-data" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(http-api-data)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -32,7 +32,8 @@ tested-with:
   GHC==9.6.7,
   GHC==9.8.4,
   GHC==9.10.1,
-  GHC==9.12.2
+  GHC==9.12.2,
+  GHC==9.14.1
 
 flag use-text-show
   description: Use text-show library for efficient ToHttpApiData implementations.
@@ -43,7 +44,7 @@ library
     hs-source-dirs: src/
 
     -- GHC bundled
-    build-depends:   base                  >= 4.12.0.0 && < 4.22
+    build-depends:   base                  >= 4.12.0.0 && < 4.23
                    , bytestring            >= 0.10.8.2 && < 0.13
                    , containers            >= 0.6.0.1  && < 0.8
                    , text                  >= 1.2.3.0  && < 1.3 || >=2.0 && <2.2

--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -94,8 +94,7 @@ test-suite spec
                    , unordered-containers
                    , uuid-types
 
-    build-depends:   HUnit                >= 1.6.0.0  && <1.7
-                   , hspec                >= 2.7.1    && <2.12
+    build-depends:   hspec                >= 2.7.1    && <2.12
                    , QuickCheck           >= 2.13.1   && <2.16
                    , quickcheck-instances >= 0.3.25.2 && <0.4
 

--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -48,7 +48,6 @@ library
                    , bytestring            >= 0.10.8.2 && < 0.13
                    , containers            >= 0.6.0.1  && < 0.8
                    , text                  >= 1.2.3.0  && < 1.3 || >=2.0 && <2.2
-                   , transformers          >= 0.5.6.2  && < 0.7
 
     -- other-dependencies
     build-depends:

--- a/test/Web/Internal/FormUrlEncodedSpec.hs
+++ b/test/Web/Internal/FormUrlEncodedSpec.hs
@@ -39,12 +39,12 @@ genericSpec = describe "Default (generic) instances" $ do
 
     it "is the right inverse of ToForm" $ property $ \x (y :: Int) -> do
       let f1 = fromList [("rec1", x), ("rec2", toQueryParam y)]
-          Right r1 = fromForm f1 :: Either Text SimpleRec
+      Right r1 :: Either Text SimpleRec <- pure $ fromForm f1
       toForm r1 `shouldBe` f1
 
     it "returns the underlying error" $ do
       let f = fromList [("rec1", "anything"), ("rec2", "bad")]
-          Left e = fromForm f :: Either Text SimpleRec
+      Left e :: Either Text SimpleRec <- pure $ fromForm f
       unpack e `shouldContain` "input does not start with a digit"
 
 urlEncoding :: Spec


### PR DESCRIPTION
My process:

- Added GHC 9.14.1 to tested-with, and allowed base-4.22 in the dependencies.
- Ran the latest haskell-ci from GitHub to add it to the GitHub CI.
- The latest haskell-ci also enables `-Werror=unused-packages`, so removed `transformers` and `HUnit` as dependencies.
- It also enables `-Werror=incomplete-uni-patterns` (not sure why), so worked around some occurrences in the tests.
- CI passes on my fork https://github.com/bmillwood/http-api-data/pull/1