### PR TITLE
Relax upper bound for text-iso8601 to 0.3

### DIFF
--- a/http-api-data.cabal
+++ b/http-api-data.cabal
@@ -53,7 +53,7 @@ library
                      cookie                >= 0.5.1    && < 0.6
                    , hashable              >= 1.4.4.0  && < 1.6
                    , http-types            >= 0.12.4   && < 0.13
-                   , text-iso8601          >= 0.1.1    && < 0.2
+                   , text-iso8601          >= 0.1.1    && < 0.3
                    , tagged                >= 0.8.8    && < 0.9
                    , time-compat           >= 1.9.5    && < 1.10
                    , uuid-types            >= 1.0.6    && < 1.1


### PR DESCRIPTION
Fixes #158

Verified with:
```sh
cabal build all
cabal test all
```

With this change `cabal-audit` no longer reports [HSEC-2026-0007](https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007):
```
Hackage package text-iso8601 at version 0.1.1.1 is vulnerable for:
  HSEC-2026-0007 "Denial of Service and Memory Exhaustion in aeson and text-iso8601"
  published: 2026-05-22 07:02:58 UTC
  https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007
  Fix available since version 0.2.0.0
  aeson, text-iso8601, dos, memory-exhaustion, json
```